### PR TITLE
Accompanying commit for firebaseco/node-orch-amqp#1 and firebaseco/node-orch-amqp#2

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -150,12 +150,13 @@ Client.prototype.connect = function connect(cb) {
         return self._processRpcTask(task);
       });
       // if calls were enabled, ensure we listen for results.
+      // the queue should be autoDelete because results are no longer relevant when the client goes away.
       self.source.listenQueue(rpcAction, function listenQueueCompleted(err, queue) {
         if (err) {
           return cb(err);
         }
         return cb(err);
-      });
+      }, true);
     } else {
       return cb(err);
     }

--- a/lib/source.js
+++ b/lib/source.js
@@ -24,8 +24,9 @@ util.inherits(TasksSource, EventEmitter);
 // Params:
 //  -> action: the name of the action to relate to.
 //  -> cb(err, queue): A callback to know when the operation finished.
+//  -> autoDelete: true to automatically remove the queue on disconnect.
 //
-TasksSource.prototype.issueQueue = function issueQueue(action, cb) {
+TasksSource.prototype.issueQueue = function issueQueue(action, cb, autoDelete) {
   if (typeof this.onIssueQueue !== 'function') {
     throw new Error("Missing onIssueQueue implementation");
   }
@@ -36,7 +37,7 @@ TasksSource.prototype.issueQueue = function issueQueue(action, cb) {
     }
     self.emit('issueQueue', action, queue);
     return cb(err, queue);
-  });
+  }, autoDelete);
 };
 
 //
@@ -44,9 +45,11 @@ TasksSource.prototype.issueQueue = function issueQueue(action, cb) {
 // Params:
 //  -> action: the name of the action to filter.
 //  -> cb(err, queue): A callback to know when the operation finished.
+//  -> autoDelete: true to automatically remove the queue on disconnect.
 //
-TasksSource.prototype.listenQueue = function listenQueue(action, cb) {
+TasksSource.prototype.listenQueue = function listenQueue(action, cb, autoDelete) {
   var self = this;
+  autoDelete = Boolean(autoDelete);
   return this.issueQueue(action, function issueQueueCompleted(err, queue) {
     if (err) {
       return cb(err, queue);
@@ -59,7 +62,7 @@ TasksSource.prototype.listenQueue = function listenQueue(action, cb) {
       self.emit('listenQueue', action, queue);
       return cb(null, queue);
     });
-  });
+  }, autoDelete);
 };
 
 //


### PR DESCRIPTION
Enables the `autoDelete` flag when creating the RPC result queue
because once the client goes away, the results are no longer relevant.
