### PR TITLE
Do not return before allowing the source to proceed to the next event.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -125,7 +125,7 @@ Client.prototype._processRpcTask = function _processRpcTask(task) {
   if (rpcTask) {
     delete this._rpcCalls[taskId];
     clearTimeout(rpcTask.timeoutId);
-    return rpcTask.callback(null, {
+    rpcTask.callback(null, {
       status: actionEntry.status,
       result: actionEntry.input
     });


### PR DESCRIPTION
When `enableRpc` is active, the `_processRpcTask()` method exits too
early, before `source.next()` can be called.  The problem is with
`return rpcTask.callback()`, when it should instead just invoke the
callback and proceed to call `source.next()` as usual.

By not calling `next()`, the message on the result queue is never
acknowledged, and no future responses will be received.
