### PR TITLE
Queue declaration must be specifically requested.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -149,14 +149,17 @@ Client.prototype.connect = function connect(cb) {
       self.source.on('task', function rpcActionTaskReceived(task) {
         return self._processRpcTask(task);
       });
-      // if calls were enabled, ensure we listen for results.
-      // the queue should be autoDelete because results are no longer relevant when the client goes away.
+      /*
+       * If calls were enabled, ensure we listen for results. To that end, the
+       * queue needs to be created and should be marked autoDelete as the
+       * results are no longer relevant when the client goes away.
+       */
       self.source.listenQueue(rpcAction, function listenQueueCompleted(err, queue) {
         if (err) {
           return cb(err);
         }
         return cb(err);
-      }, true);
+      }, true, true);
     } else {
       return cb(err);
     }

--- a/lib/source.js
+++ b/lib/source.js
@@ -26,7 +26,7 @@ util.inherits(TasksSource, EventEmitter);
 //  -> cb(err, queue): A callback to know when the operation finished.
 //  -> autoDelete: true to automatically remove the queue on disconnect.
 //
-TasksSource.prototype.issueQueue = function issueQueue(action, cb, autoDelete) {
+TasksSource.prototype.issueQueue = function issueQueue(action, cb, requiresDeclaration, autoDelete) {
   if (typeof this.onIssueQueue !== 'function') {
     throw new Error("Missing onIssueQueue implementation");
   }
@@ -37,7 +37,7 @@ TasksSource.prototype.issueQueue = function issueQueue(action, cb, autoDelete) {
     }
     self.emit('issueQueue', action, queue);
     return cb(err, queue);
-  }, autoDelete);
+  }, requiresDeclaration, autoDelete);
 };
 
 //
@@ -47,7 +47,7 @@ TasksSource.prototype.issueQueue = function issueQueue(action, cb, autoDelete) {
 //  -> cb(err, queue): A callback to know when the operation finished.
 //  -> autoDelete: true to automatically remove the queue on disconnect.
 //
-TasksSource.prototype.listenQueue = function listenQueue(action, cb, autoDelete) {
+TasksSource.prototype.listenQueue = function listenQueue(action, cb, requiresDeclaration, autoDelete) {
   var self = this;
   autoDelete = Boolean(autoDelete);
   return this.issueQueue(action, function issueQueueCompleted(err, queue) {
@@ -62,7 +62,7 @@ TasksSource.prototype.listenQueue = function listenQueue(action, cb, autoDelete)
       self.emit('listenQueue', action, queue);
       return cb(null, queue);
     });
-  }, autoDelete);
+  }, requiresDeclaration, autoDelete);
 };
 
 //

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -81,7 +81,7 @@ Worker.prototype.start = function start(callback) {
               return next(err);
             }
             return nextAction();
-          });
+          }, true);
         } else {
           // Finished Creating Action Queues
           return next();


### PR DESCRIPTION
This change requires specific declaration of the queues used to listen-for and publish events. This is to support the (soon-to-be-pull-requested) related change in orch-amqp to set node-amqp's queue noDeclare option and avoid an exception caused by pre-created queues with different, which causes issues with newer versions of RabbitMQ.
