### PR TITLE
Race condition in `TasksSource#connect()`

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -74,8 +74,14 @@ TasksSource.prototype.connect = function connect(callback) {
   if (typeof callback !== 'function') {
     throw new Error("callback required");
   }
-  if (this.isConnected || this.isConnecting) {
+  if (this.isConnected) {
     return callback(null);
+  } else if (this.isConnecting) {
+    // Someone else has already started this connection, so wait for the 'connected' event to be fired.
+    this.once('connected', function(err) {
+      callback(err);
+    });
+    return;
   }
   if (typeof this.onConnect !== 'function') {
     throw new Error("Missing onConnect implementation");

--- a/test/source-test.js
+++ b/test/source-test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var orch = require('../index.js');
+var assert = require('assert');
+var vows = require('vows');
+var TestSource = require('./test-source');
+var util = require('util');
+
+vows.describe('Orch Source').addBatch({
+  "Source#connect() waits for actual connection": {
+    topic: new TestSource(),
+
+    "When I call connect(), the source is actively connecting": function(err, source) {
+      source.connect(function(err){});
+      assert.isTrue(source.isConnecting);
+      assert.isFalse(source.isConnected);
+    },
+    "If I call connect() a second time, the callback waits until it is connected.": {
+      topic: function(source) {
+        var cb = this.callback;
+        source.connect(function(err) { cb(err, source); });
+      },
+      "the callback waits until it is connected.": function(err, source) {
+        assert.isTrue(source.isConnected);
+        assert.isFalse(source.isConnecting);
+      }
+    }
+  }
+}).export(module);

--- a/test/test-source.js
+++ b/test/test-source.js
@@ -62,7 +62,7 @@ function TestWorkerTasksSource() {
 util.inherits(TestWorkerTasksSource, TasksSource);
 
 TestWorkerTasksSource.prototype.onConnect = function onConnect(cb) {
-  return cb(null);
+  setTimeout(function() { cb(); }, 200);
 };
 
 TestWorkerTasksSource.prototype.onIssueQueue = function onIssueQueue(action, cb) {


### PR DESCRIPTION
Currently the source will immediately call the connect callback if it's
already in `isConnected==true` OR `isConnecting==true` state, but that
allows the callback to receive a not-yet-connected source.
Example (test case):

```
source = new TestSource();
source.connect(function() { console.log('1'); });
source.connect(function() { console.log('2'); });
```

The above case would log `'2'` before `'1'`, and in the `'2'` case, the
source is actually not connected yet.

This code change instead uses the `on('connected')` event to trigger
the callback.
